### PR TITLE
Whois info

### DIFF
--- a/models/general/knowledge/en/whois.txt
+++ b/models/general/knowledge/en/whois.txt
@@ -1,0 +1,9 @@
+# Whois Information for a domain
+
+whois *
+!console:$plaintext$
+{ 
+    "url": "https://api.wolframalpha.com/v2/query?input=whois+$1$&output=JSON&appid=9WA6XR-26EWTGEVTE",  
+    "path" : "$.queryresult.pods[1].subpods[0]"
+}
+eol


### PR DESCRIPTION
For ex: 

`whois facebook` returns 
```
name | Facebook, Inc
location | Palo Alto, California, United States
coordinates | 37° 23' 59"N, 122° 8' 34"W
```
