### PR TITLE
Finds synonyms for a word

### DIFF
--- a/models/general/knowledge/en/synonym.txt
+++ b/models/general/knowledge/en/synonym.txt
@@ -1,0 +1,7 @@
+synonym of *
+!console:$plaintext$
+{ 
+    "url": "https://api.wolframalpha.com/v2/query?input=synonym+of+$1$&output=JSON&appid=9WA6XR-26EWTGEVTE",  
+    "path" : "$.queryresult.pods[1].subpods[0]"
+}
+eol


### PR DESCRIPTION
Fixes issue https://github.com/fossasia/susi_skill_data/issues/50: No skill present to return synonyms for a given word

Etherpad for testing: http://dream.susi.ai/p/synonym

Changes: adds synonym.txt to fetch a list of synonyms for a specific word

![screen shot 2017-05-31 at 4 57 25 pm](https://cloud.githubusercontent.com/assets/8962264/26629977/4e329796-4622-11e7-8ae4-cfb9f7dbe1c5.png)
