### PR TITLE
Fixes #53, added skill in knowledge to tell about people in space

### DIFF
--- a/models/general/knowledge/en/astronauts.txt
+++ b/models/general/knowledge/en/astronauts.txt
@@ -1,0 +1,20 @@
+# Tells about people in space
+How many people are In space right now
+!console:There are currently $object$ humans in space.
+{
+"url":"http://api.open-notify.org/astros.json",
+"path":"$.number"
+}
+eol
+
+What are the name of those astronauts?
+!console:
+{
+"url":"http://api.open-notify.org/astros.json",
+"path":"$.people",
+"actions":[{
+"type":"table",
+"columns":{"name":"Name","craft":"Craft"}
+}]
+}
+eol


### PR DESCRIPTION
Fixes #53 - added skill to knowledge

Changes: added `astronauts.txt` - action type table, skill to tell about people in space.

Etherpad dream link for testing - [http://dream.susi.ai/p/astros](http://dream.susi.ai/p/astros)
Service used - [http://api.open-notify.org/](http://api.open-notify.org/)

Screenshot for the Change:
![image](https://cloud.githubusercontent.com/assets/9781788/26640736/2a294c90-4646-11e7-9cfa-81cd28ddbcee.png)

