### PR TITLE
Fixes #52 - F1 Race stats as table

### DIFF
--- a/models/general/entertainment/en/f1_racing.txt
+++ b/models/general/entertainment/en/f1_racing.txt
@@ -52,11 +52,24 @@ f1 constructor *
 }
 eol
 
-#f1 driver hamilton
+#Ex: f1 driver hamilton
 f1 driver *
 !console:$givenName$ $familyName$ was born on $dateOfBirth$. His nationality is $nationality$ - $url$ for more details
 {
 "url":"http://ergast.com/api/f1/drivers/$1$.json",
 "path":"$.MRData.DriverTable.Drivers[0]"
+}
+eol
+
+Ex: race summary of hamilton in f1 season 2009
+race summary of  * in f1 season *|race stats of  * in f1 season *
+!console:
+{
+"url":"http://ergast.com/api/f1/$2$/drivers/$1$/status.json",
+"path":"$.MRData.StatusTable.Status",
+"actions":[{
+"type":"table",
+"columns":{"status":"Race Status","count":"Number Of Races"}
+}]
 }
 eol


### PR DESCRIPTION
**Entertainment**
**en/f1_racing.txt:** Fixes #52 
**Sample Query :** race summary of hamilton in f1 season 2009
**Response:** Gives a table of race status and count

![f1](https://cloud.githubusercontent.com/assets/13276887/26640064/3a279d10-4644-11e7-9272-2e45c5794a69.png)


**Etherpad Link:** http://dream.susi.ai/p/f1stats
