### PR TITLE
Added skill to tell half life of radioactive elements (belongs to knowledge topic)

### DIFF
--- a/models/general/knowledge/en/half_life.txt
+++ b/models/general/knowledge/en/half_life.txt
@@ -1,0 +1,8 @@
+#Tells us half life of radioactive elements e.g Half life of uranium
+What is half life of *|Tell me half life of *|half life of *|* half life
+!console:$alt$
+{
+"url":"http://api.wolframalpha.com/v2/query?appid=9WA6XR-26EWTGEVTE&input=what+is+half+life+of+$1$&output=JSON",
+"path":"$.queryresult.pods[1].subpods[0].img"
+}
+eol


### PR DESCRIPTION
Fixes issue #55 

Changes: 

Added skill to tell half life of radioactive elements e.g half life of uranium

Screenshots for the change: 

![half life](https://cloud.githubusercontent.com/assets/25840461/26651218/687302a6-4665-11e7-8efd-059a87701ab9.PNG)

Etherpad Link: http://dream.susi.ai/p/halflife