### PR TITLE
added skill to tell atomic mass unit of an element

### DIFF
--- a/models/general/knowledge/en/atomic_mass.txt
+++ b/models/general/knowledge/en/atomic_mass.txt
@@ -1,0 +1,7 @@
+Tell the atomic mass of * | atomic mass of * | * atomic mass  
+!console:The atomic mass of $1$ is $plaintext$ 
+{
+"url":"https://api.wolframalpha.com/v2/query?input=atomic+mass+of+$1$&format=plaintext&output=JSON&appid=9WA6XR-26EWTGEVTE",
+"path":"$.queryresult.pods[1].subpods"
+}
+eol


### PR DESCRIPTION
Fixes issue #65 

Changes: added `atomic_mass.txt` in knowledge

Screenshots for the change: 
![image](https://cloud.githubusercontent.com/assets/9781788/26656467/d4143784-467c-11e7-969d-66eede4438a9.png)

Etherpad link for testing - [http://dream.susi.ai/p/amu](http://dream.susi.ai/p/amu)