### PR TITLE
Added skill to tell values of scientific constants (belongs to knowledge topic)

### DIFF
--- a/models/general/knowledge/en/Scientific_constant_values.txt
+++ b/models/general/knowledge/en/Scientific_constant_values.txt
@@ -1,0 +1,8 @@
+#Tells value of all scietific constants
+Value of *|What is value of *|* Value
+!console:Value of $1$ is $alt$
+{
+"url":"http://api.wolframalpha.com/v2/query?appid=9WA6XR-26EWTGEVTE&input=value+of+$1$&output=JSON",
+"path":"$.queryresult.pods[1].subpods[0].img"
+}
+eol


### PR DESCRIPTION
Fixes issue #77 

Changes:

Added skill to tell values of scientific constants.

Screenshots for the change: 

![values](https://cloud.githubusercontent.com/assets/25840461/26732301/94d6aa8e-47d0-11e7-935a-7c922a5e628f.PNG)

Etherpad Link: http://dream.susi.ai/p/values