### PR TITLE
added skill to give list of football team players

### DIFF
--- a/models/general/knowledge/en/football_teams.txt
+++ b/models/general/knowledge/en/football_teams.txt
@@ -1,0 +1,86 @@
+# give table for football teams and its players
+
+tell me the teams in premier leauge| Premier leauge teams
+!console:
+{
+  "url":"http://api.football-data.org/v1/competitions/398/teams",
+  "path":"$.teams",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","code":"Code","shortName":"Short Name","crestUrl":Logo}
+  }]
+}
+eol
+
+
+give me details of Manchester United | Manchester United team players 
+!console:
+{
+  "url":"http://api.football-data.org/v1/teams/66/players",
+  "path":"$.players",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","position":"Position","jerseyNumber":"Jersey Number","nationality":"Nationality"}
+  }]
+}
+eol
+
+give me details of Bayern Munich | Bayern Munich team players 
+!console:
+{
+  "url":"http://api.football-data.org/v1/teams/5/players",
+  "path":"$.players",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","position":"Position","jerseyNumber":"Jersey Number","nationality":"Nationality"}
+  }]
+}
+eol
+give me details of Barcelona  | Barcelona team players 
+!console:
+{
+  "url":"http://api.football-data.org/v1/teams/81/players",
+  "path":"$.players",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","position":"Position","jerseyNumber":"Jersey Number","nationality":"Nationality"}
+  }]
+}
+eol
+
+give details of Real Madrid | Real Madrid team players
+!console:
+{
+  "url":"http://api.football-data.org/v1/teams/86/players",
+  "path":"$.players",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","position":"Position","jerseyNumber":"Jersey Number","nationality":"Nationality"}
+  }]
+}
+eol
+
+give details of Chelsea FC | Chelsea team players
+!console:
+{
+  "url":"http://api.football-data.org/v1/teams/72/players",
+  "path":"$.players",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","position":"Position","jerseyNumber":"Jersey Number","nationality":"Nationality"}
+  }]
+}
+eol
+
+give details of Arsenal FC |Arsenal FC team players
+!console:
+{
+  "url":"http://api.football-data.org/v1/teams/563/players",
+  "path":"$.players",
+  "actions":[{
+    "type":"table",
+    "columns":{"name":"Name","position":"Position","jerseyNumber":"Jersey Number","nationality":"Nationality"}
+  }]
+}
+eol
+


### PR DESCRIPTION
Fixes issue #71 

Changes: added `footbal_team.txt` to tell about team players
The details are provided only for some teams, will search for some way to map all the team name with team numbers.

Screenshots for the change: 
![image](https://cloud.githubusercontent.com/assets/9781788/26750266/ae6475ba-483b-11e7-8d06-b5c2e424b025.png)
![image](https://cloud.githubusercontent.com/assets/9781788/26750271/c791a7f6-483b-11e7-9950-49cc4946c1db.png)

Ehterpad link for testing [http://dream.susi.ai/p/football_team_player](http://dream.susi.ai/p/football_team_player)
