### PR TITLE
Added kill to tell price of products in different currencies

### DIFF
--- a/models/general/knowledge/en/price_in_different_currencies.txt
+++ b/models/general/knowledge/en/price_in_different_currencies.txt
@@ -1,0 +1,8 @@
+#Tells price of  products in different currencies 
+Price of  * in * 
+!console:Price of $1$ in $2$ is $alt$
+{
+"url":"http://api.wolframalpha.com/v2/query?appid=9WA6XR-26EWTGEVTE&input=price+of+$1$+in+$2$&output=JSON",
+"path":"$.queryresult.pods[1].subpods[0].img"
+}
+eol


### PR DESCRIPTION
Fixes issue #91 

Changes: 

Added skill to tell price of products in different currencies

Screenshots for the change: 

![price](https://cloud.githubusercontent.com/assets/25840461/26764047/aea99634-4978-11e7-988e-59276cd98056.PNG)

Etherpad Link: http://dream.susi.ai/p/price
