### PR TITLE
Added skill to tell power consumption in year of world (belongs to knowledge topic)

### DIFF
--- a/models/general/knowledge/en/power_consumtpion.txt
+++ b/models/general/knowledge/en/power_consumtpion.txt
@@ -1,7 +1,7 @@
-Power consumption per year|what is the power consumption per year|Tell me about of power consumption per year
+Power consumption per year in *|what is the power consumption per year in *|Tell me about of power consumption per year in *|Power consumption in *
 !console:$alt$
 {
-"url":"http://api.wolframalpha.com/v2/query?appid=9WA6XR-26EWTGEVTE&input=power%20consumption%20per%20year&output=JSON",
+"url":"http://api.wolframalpha.com/v2/query?appid=9WA6XR-26EWTGEVTE&input=power%20consumption%20in%20$1$&output=JSON",
 "path":"$.queryresult.pods[1].subpods[0].img"
 }
 eol

--- a/models/general/knowledge/en/power_consumtpion.txt
+++ b/models/general/knowledge/en/power_consumtpion.txt
@@ -1,0 +1,7 @@
+Power consumption per year|what is the power consumption per year|Tell me about of power consumption per year
+!console:$alt$
+{
+"url":"http://api.wolframalpha.com/v2/query?appid=9WA6XR-26EWTGEVTE&input=power%20consumption%20per%20year&output=JSON",
+"path":"$.queryresult.pods[1].subpods[0].img"
+}
+eol


### PR DESCRIPTION
Fixes issue #95 

Changes: 

Added skill to tell power consumption in year of world

Screenshots for the change: 

![power](https://user-images.githubusercontent.com/25840461/26856344-8398ebbe-4b3c-11e7-8473-9c083953ad6f.PNG)

Etherpad Link: http://dream.susi.ai/p/powerconsumption
