### PR TITLE
Added skill to tell latest exchange rate for a currency

### DIFF
--- a/models/general/knowledge/en/currency_to_bitcoin.txt
+++ b/models/general/knowledge/en/currency_to_bitcoin.txt
@@ -1,53 +1,53 @@
-What is latest exchange rate for US dollars|What is latest exchange rate for USD
-!console:Latest exchange rate is $last$
+What is latest exchange rate for US dollars to bitcoin|What is latest exchange rate for USD to BTC
+!console:Latest exchange rate is 1 BTC = $last$ USD 
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.USD."
 }
 eol
 
-What is latest exchange rate for Euros|What is latest exchange rate for EUR
-!console:Latest exchange rate is $last$
+What is latest exchange rate for Euros to bitcoin|What is latest exchange rate for EUR to BTC
+!console:Latest exchange rate is 1 BTC = $last$ EUR
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.EUR."
 }
 eol
 
-What is latest exchange rate for canadian dollars|What is latest exchange rate for CAD
-!console:Latest exchange rate is $last$
+What is latest exchange rate for canadian dollars to bitcoin|What is latest exchange rate for CAD to BTC
+!console:Latest exchange rate is 1 BTC = $last$ CAD 
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.CAD."
 }
 eol
 
-What is latest exchange rate for Indian rupees|What is latest exchange rate for INR
-!console:Latest exchange rate is $last$
+What is latest exchange rate for Indian rupees to bitcoin|What is latest exchange rate for INR to BTC
+!console:Latest exchange rate is 1 BTC = $last$ INR
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.INR."
 }
 eol
 
-What is latest exchange rate for australian dollars|What is latest exchange rate for AUD
-!console:Latest exchange rate is $last$
+What is latest exchange rate for australian dollars to bitcoin|What is latest exchange rate for AUD to BTC
+!console:Latest exchange rate is 1 BTC = $last$ AUD 
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.AUD."
 }
 eol
 
-What is latest exchange rate for Chinese yen|What is latest exchange rate for CNY
-!console:Latest exchange rate is $last$
+What is latest exchange rate for Chinese yen to bitcoin|What is latest exchange rate for CNY to BTC
+!console:Latest exchange rate is 1 BTC = $last$ CNY  
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.CNY."
 }
 eol
 
-What is latest exchange rate for japenese yen|What is latest exchange rate for JPY
-!console:Latest exchange rate is $last$
+What is latest exchange rate for japenese yen to bitcoin|What is latest exchange rate for JPY to BTC
+!console:Latest exchange rate is 1 BTC = $last$ JPY
 {
 "url":"https://blockchain.info/ticker",
 "path":"$.JPY."

--- a/models/general/knowledge/en/currency_to_bitcoin.txt
+++ b/models/general/knowledge/en/currency_to_bitcoin.txt
@@ -1,0 +1,55 @@
+What is latest exchange rate for US dollars|What is latest exchange rate for USD
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.USD."
+}
+eol
+
+What is latest exchange rate for Euros|What is latest exchange rate for EUR
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.EUR."
+}
+eol
+
+What is latest exchange rate for canadian dollars|What is latest exchange rate for CAD
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.CAD."
+}
+eol
+
+What is latest exchange rate for Indian rupees|What is latest exchange rate for INR
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.INR."
+}
+eol
+
+What is latest exchange rate for australian dollars|What is latest exchange rate for AUD
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.AUD."
+}
+eol
+
+What is latest exchange rate for Chinese yen|What is latest exchange rate for CNY
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.CNY."
+}
+eol
+
+What is latest exchange rate for japenese yen|What is latest exchange rate for JPY
+!console:Latest exchange rate is $last$
+{
+"url":"https://blockchain.info/ticker",
+"path":"$.JPY."
+}
+eol

--- a/models/general/knowledge/en/currency_to_bitcoin.txt
+++ b/models/general/knowledge/en/currency_to_bitcoin.txt
@@ -1,4 +1,4 @@
-What is latest exchange rate for US dollars to bitcoin|What is latest exchange rate for USD to BTC
+value of a bitcoin| convert bitcoin to usd| convert btc to usd| convert btc to us dollars| convert btc to us dollar| btc to us dollar|btc to us dollars|btc to usd|what is latest exchange rate for US dollars to bitcoin|what is latest exchange rate for USD to BTC | can you tell me value of a bitcoin| can you convert bitcoin to usd| can you convert btc to usd| can you convert btc to us dollars| can you convert btc to us dollar| btc to us dollar|btc to us dollars|btc to usd|can you tell me what is latest exchange rate for US dollars to bitcoin|can you tell me what is latest exchange rate for USD to BTC |could you tell me what is latest exchange rate for USD to BTC | could you tell me value of a bitcoin| could you convert bitcoin to usd| could you convert btc to usd| could you convert btc to us dollars| could you convert btc to us dollar| btc to us dollar|btc to us dollars|btc to usd|could you tell me what is latest exchange rate for US dollars to bitcoin|could you tell me what is latest exchange rate for USD to BTC | do you know what is latest exchange rate for USD to BTC | do you know the value of a bitcoin| can you convert bitcoin to usd| can you convert btc to usd| can you convert btc to us dollars| can you convert btc to us dollar| btc to us dollar|btc to us dollars|btc to usd|do you know the latest exchange rate for US dollars to bitcoin|do you know what is the latest exchange rate for USD to BTC
 !console:Latest exchange rate is 1 BTC = $last$ USD 
 {
 "url":"https://blockchain.info/ticker",
@@ -6,7 +6,7 @@ What is latest exchange rate for US dollars to bitcoin|What is latest exchange r
 }
 eol
 
-What is latest exchange rate for Euros to bitcoin|What is latest exchange rate for EUR to BTC
+convert bitcoin to euros | convert btc to eur| convert btc to euros| convert btc to euros| btc to euros|btc to euros|btc to euros|what is latest exchange rate for euros to bitcoin|what is latest exchange rate for euros to BTC | can you convert bitcoin to euros| can you convert btc to euros| can you convert btc to eur| can you convert btc to eur| btc to eur|btc to eur|btc to eur|can you tell me what is latest exchange rate for eur to bitcoin|can you tell me what is latest exchange rate for eur to btc |could you tell me what is latest exchange rate for eur to btc |could you convert bitcoin to eur| could you convert btc to eur| could you convert btc to eur| could you convert btc to euros| btc to euros|btc to euros|btc to euros|could you tell me what is latest exchange rate for euros to bitcoin|could you tell me what is latest exchange rate for eur to btc | do you know what is latest exchange rate for eur to btc | can you convert bitcoin to eur| can you convert btc to eur| can you convert btc to eur| can you convert btc to euros| btc to euros|btc to euros|btc to eur|do you know the latest exchange rate for euros to bitcoin|do you know what is the latest exchange rate for euros to btc
 !console:Latest exchange rate is 1 BTC = $last$ EUR
 {
 "url":"https://blockchain.info/ticker",
@@ -14,7 +14,7 @@ What is latest exchange rate for Euros to bitcoin|What is latest exchange rate f
 }
 eol
 
-What is latest exchange rate for canadian dollars to bitcoin|What is latest exchange rate for CAD to BTC
+convert bitcoin to cad| convert btc to cad| convert btc to canadian dollars| convert btc to canadian dollar| btc to canadian dollar|btc to canadian dollars|btc to cad|what is latest exchange rate for canadian dollars to bitcoin|what is latest exchange rate for cad to btc | can you convert bitcoin to cad| can you convert btc to cad| can you convert btc to canadian dollars| can you convert btc to canadian dollar| btc to canadian dollars|btc to canadian dollars|btc to cad|can you tell me what is latest exchange rate for canadian dollars to bitcoin|can you tell me what is latest exchange rate for cad to btc |could you tell me what is latest exchange rate for cad to btc | could you convert bitcoin to cad| could you convert btc to cad| could you convert btc to canadian dollars| could you convert btc to canadian dollar| btc to canadian dollar|btc to canadian dollars|btc to cad|could you tell me what is latest exchange rate for canadian dollars to bitcoin|could you tell me what is latest exchange rate for cad to btc | do you know what is latest exchange rate for cad to btc | can you convert bitcoin to cad| can you convert btc to cad| can you convert btc to canadian dollars| can you convert btc to canandian dollar| btc to canadian dollar|btc to canadian dollars|btc to cad|do you know the latest exchange rate for canadian dollars to bitcoin|do you know what is the latest exchange rate for cad to btc
 !console:Latest exchange rate is 1 BTC = $last$ CAD 
 {
 "url":"https://blockchain.info/ticker",
@@ -22,7 +22,7 @@ What is latest exchange rate for canadian dollars to bitcoin|What is latest exch
 }
 eol
 
-What is latest exchange rate for Indian rupees to bitcoin|What is latest exchange rate for INR to BTC
+convert bitcoin to inr| convert btc to inr| convert btc to indian rupees| convert btc to indian rupees| btc to indian rupees|btc to indian rupees|btc to inr|what is latest exchange rate for indian rupees to bitcoin|what is latest exchange rate for inr to btc | can you convert bitcoin to inr| can you convert btc to inr| can you convert btc to indian rupees| can you convert btc to indian rupees| btc to indian rupees|btc to indian rupees|btc to inr|can you tell me what is latest exchange rate for indian rupees to bitcoin|can you tell me what is latest exchange rate for inr to btc |could you tell me what is latest exchange rate for inr to btc | could you convert bitcoin to inr| could you convert btc to inr| could you convert btc to indian rupees| could you convert btc to indian rupees| btc to indian rupees|btc to inr|could you tell me what is latest exchange rate for indian rupees to bitcoin|could you tell me what is latest exchange rate for inr to btc | do you know what is latest exchange rate for inr to btc | can you convert bitcoin to inr| can you convert btc to inr| can you convert btc to indian rupees| can you convert btc to indian rupees| btc to indian rupees|btc to indian rupees|btc to inr|do you know the latest exchange rate for indian rupees to bitcoin|do you know what is the latest exchange rate for inr to btc
 !console:Latest exchange rate is 1 BTC = $last$ INR
 {
 "url":"https://blockchain.info/ticker",
@@ -30,7 +30,7 @@ What is latest exchange rate for Indian rupees to bitcoin|What is latest exchang
 }
 eol
 
-What is latest exchange rate for australian dollars to bitcoin|What is latest exchange rate for AUD to BTC
+convert bitcoin to aud| convert btc to aud| convert btc to australian dollars| convert btc to australian dollars| btc to australian dollars|btc to australian dollars|btc to aud|what is latest exchange rate for australian dollars to bitcoin|what is latest exchange rate for aud to btc | can you convert bitcoin to aud| can you convert btc to aud| can you convert btc to australian dollars| can you convert btc to australian dollars| btc to australian dollars|btc to australian dollars|btc to aud|can you tell me what is latest exchange rate for australian dollars to bitcoin|can you tell me what is latest exchange rate for aud to btc |could you tell me what is latest exchange rate for aud to btc | could you convert bitcoin to aud| could you convert btc to aud| could you convert btc to australian dollars| could you convert btc to australian dollars| btc to australian dollars|btc to aud|could you tell me what is latest exchange rate for australian dollars to bitcoin|could you tell me what is latest exchange rate for aud to btc | do you know what is latest exchange rate for aud to btc | can you convert bitcoin to aud| can you convert btc to aud| can you convert btc to australian dollars| can you convert btc to canandian dollar| btc to australian dollars|btc to australian dollars|btc to aud|do you know the latest exchange rate for australian dollars to bitcoin|do you know what is the latest exchange rate for aud to btc
 !console:Latest exchange rate is 1 BTC = $last$ AUD 
 {
 "url":"https://blockchain.info/ticker",
@@ -38,7 +38,7 @@ What is latest exchange rate for australian dollars to bitcoin|What is latest ex
 }
 eol
 
-What is latest exchange rate for Chinese yen to bitcoin|What is latest exchange rate for CNY to BTC
+convert bitcoin to cny| convert btc to cny| convert btc to chinese yen| convert btc to chinese yen| btc to chinese yen|btc to chinese yen|btc to cny|what is latest exchange rate for chinese yen to bitcoin|what is latest exchange rate for cny to btc | can you convert bitcoin to cny| can you convert btc to cny| can you convert btc to chinese yen| can you convert btc to chinese yen| btc to chinese yen|btc to chinese yen|btc to cny|can you tell me what is latest exchange rate for chinese yen to bitcoin|can you tell me what is latest exchange rate for cny to btc |could you tell me what is latest exchange rate for cny to btc | could you convert bitcoin to cny| could you convert btc to cny| could you convert btc to chinese yen| could you convert btc to chinese yen| btc to chinese yen|btc to chinese yen|btc to cny|could you tell me what is latest exchange rate for chinese yen to bitcoin|could you tell me what is latest exchange rate for cny to btc | do you know what is latest exchange rate for cny to btc | can you convert bitcoin to cny| can you convert btc to cny| can you convert btc to chinese yen| can you convert btc to canandian dollar| btc to chinese yen|btc to chinese yen|btc to cny|do you know the latest exchange rate for chinese yen to bitcoin|do you know what is the latest exchange rate for cny to btc
 !console:Latest exchange rate is 1 BTC = $last$ CNY  
 {
 "url":"https://blockchain.info/ticker",
@@ -46,7 +46,7 @@ What is latest exchange rate for Chinese yen to bitcoin|What is latest exchange 
 }
 eol
 
-What is latest exchange rate for japenese yen to bitcoin|What is latest exchange rate for JPY to BTC
+convert bitcoin to jpy| convert btc to jpy| convert btc to japanese yen| convert btc to japanese yen| btc to japanese yen|btc to japanese yen|btc to jpy|what is latest exchange rate for japanese yen to bitcoin|what is latest exchange rate for jpy to btc | can you convert bitcoin to jpy| can you convert btc to jpy| can you convert btc to japanese yen| can you convert btc to japanese yen| btc to japanese yen|btc to japanese yen|btc to jpy|can you tell me what is latest exchange rate for japanese yen to bitcoin|can you tell me what is latest exchange rate for jpy to btc |could you tell me what is latest exchange rate for jpy to btc | could you convert bitcoin to jpy| could you convert btc to jpy| could you convert btc to japanese yen| could you convert btc to japanese yen| btc to japanese yen|btc to japanese yen|btc to jpy|could you tell me what is latest exchange rate for japanese yen to bitcoin|could you tell me what is latest exchange rate for jpy to btc | do you know what is latest exchange rate for jpy to btc | can you convert bitcoin to jpy| can you convert btc to jpy| can you convert btc to japanese yen| can you convert btc to canandian dollar| btc to japanese yen|btc to japanese yen|btc to jpy|do you know the latest exchange rate for japanese yen to bitcoin|do you know what is the latest exchange rate for jpy to btc
 !console:Latest exchange rate is 1 BTC = $last$ JPY
 {
 "url":"https://blockchain.info/ticker",


### PR DESCRIPTION
Fixes issue #109 

Changes: 
A skill added to tell the latest exchange rates of a currency equivalent to 1 bitcoin.

Screenshots for the change: 
<img width="514" alt="bitcoin" src="https://user-images.githubusercontent.com/20307535/26962786-46656a12-4d06-11e7-8c0e-a376bc109402.PNG">

Susi dream link: 
http://dream.susi.ai/p/currencytobitcoin
