### PR TITLE
Adding more skills based on image response 

### DIFF
--- a/models/general/entertainment/en/images.txt
+++ b/models/general/entertainment/en/images.txt
@@ -1,0 +1,32 @@
+latest images
+!console:
+{
+    "url":"http://www.splashbase.co/api/v1/images/latest",
+    "path":"$.images",
+    "actions":[{
+        "type":"table",
+        "columns":{"url":"URL"}
+        }]
+}
+eol
+
+random image
+!console:$object$
+{
+    "url":"http://www.splashbase.co/api/v1/images/random",
+    "path":"$.url"
+}
+eol
+
+images of *
+!console:
+{
+    "url":"http://www.splashbase.co/api/v1/images/search?query=$1$",
+    "path":"$.images",
+    "actions":[{
+        "type":"table",
+        "columns":{"url":"URL"}
+        }]
+}
+eol
+

--- a/models/general/entertainment/en/images.txt
+++ b/models/general/entertainment/en/images.txt
@@ -19,14 +19,4 @@ random image
 eol
 
 images of *
-!console:
-{
-    "url":"http://www.splashbase.co/api/v1/images/search?query=$1$",
-    "path":"$.images",
-    "actions":[{
-        "type":"table",
-        "columns":{"url":"URL"}
-        }]
-}
-eol
-
+https://source.unsplash.com/1600x900/?$1$


### PR DESCRIPTION
Fixes issue #81 

Changes: images skill added. 
**What it does?**
1. gives a random image
2. gives link to an image on a particular search query
3. gives top 5 links to latest images
dream [link](http://dream.susi.ai/p/images)

Screenshots for the change: 
![of_n_latest](https://user-images.githubusercontent.com/14837478/26984610-ad531902-4d5d-11e7-809d-adadaea58d0e.png)
![random](https://user-images.githubusercontent.com/14837478/26984609-ad51d7cc-4d5d-11e7-8771-bc0de1736f17.png)
