### PR TITLE
Added Answer Action text for University Skill

### DIFF
--- a/models/general/knowledge/en/university.txt
+++ b/models/general/knowledge/en/university.txt
@@ -2,7 +2,7 @@
 
 universities in *|tell me universities in * |do you know the universities in *|find universities in *| show universities in *| search for universities in *| name the universities in *| tell me about universities in *|give me list of universities in *| What all universities are in *|tell me names of universities in *|tell me the names of universities in *|can you tell me names of universities in *|can you tell me the names of universities in *|do you know the any universities in *|do you know the names of universities in *|which are universities in *|which universities are in *|Provide me list of universities in *|
 !example:universities in germany
-!console:
+!console: Sure, here is a list of universities
 {
 "url":"http://universities.hipolabs.com/search?country=$1$",
 "path":"$",


### PR DESCRIPTION
Fixes issue #253

Etherpad Link: Minor change to existing skill. Link not required.

Changes: Added an Answer Action Text to the University skill. Now instead of just showing results, it will also supply "Sure, here is a list of universities" as answer action which TTS interfaces can speak. 

Screenshots for the change: Not required.
