### PR TITLE
Describes action type websearch.

### DIFF
--- a/models/general/Knowledge/en/websearch.txt
+++ b/models/general/Knowledge/en/websearch.txt
@@ -9,11 +9,14 @@
 
 #query from duckduckgo
 search *|query *|duckduckgo *| find the web for *| search the web for *| search for *| What is  *| find about *| websearch for *| websearch * | find * | search internet for * | search duckduckgo for * | search google * | google * | google for * | search google for *| google this *| find * on google | find * on duckduckgo | find * on internet| find about * on internet | find about * on google |find about * on duckduckgo | find about * on web | look for * | look google for * | look duckduckgo for * | look * on google | look * on web | about * on google | about * on duckduckgo | about * on internet | find * on internet | search internet for * | internet * | web * | look for information on * |look for information on google for * | look for information on duckduckgo about * | look for information about * 
-!example: find the web for software
-!expect:Software A part of a computer system that consists of data or computer instructions.
-!console:$Text$ $FirstURL$
+!example: search for dog
+!console:Here is a websearch result:
 {
     "url":"http://api.duckduckgo.com/?q=$1$&format=json&pretty=1",
-    "path":"$.RelatedTopics[0]"
+    "path":"$",
+    "actions":[{ 
+    "type":"websearch",
+    "query":$1$
+    }]
 }
 eol


### PR DESCRIPTION
This will show the search results in the form horizontal card list.

Fixes issue #308 

Etherpad Link: [https://dream.susi.ai/p/saurabh1](url)

Changes: Described the action type as websearch.

Demo Link:http://bewildered-print.surge.sh/