### PR TITLE
Fix empty category by adding placeholder skill

### DIFF
--- a/models/custom/Alarms and Clocks/placeholder.json
+++ b/models/custom/Alarms and Clocks/placeholder.json
@@ -1,0 +1,14 @@
+{
+  "name": "Placeholder Skill",
+  "language": "en",
+  "examples": [
+    "What can you do?",
+    "Help me"
+  ],
+  "responses": [
+    {
+      "type": "answer",
+      "expression": "This placeholder skill prevents the category from being empty."
+    }
+  ]
+}


### PR DESCRIPTION
This pull request fixes an empty category under models/custom.

A minimal placeholder skill has been added to ensure the category contains at least one valid skill, preventing empty categories from appearing on skills.susi.ai.

Fixes #317

## Summary by Sourcery

Bug Fixes:
- Prevent the Alarms and Clocks custom skill category from appearing empty on skills.susi.ai by adding a minimal placeholder skill.