### PR TITLE
Fix Play Salsa on YouTube skill to use search results

### DIFF
--- a/models/general/Music and Audio/en/music.txt
+++ b/models/general/Music and Audio/en/music.txt
@@ -44,3 +44,30 @@ play any * genre from * from mixcloud|play any * shows from * from mixcloud
 "path":"$.url"
 }
 eol
+# Ex: play salsa on youtube
+play salsa on youtube|play salsa music on youtube
+!example:play salsa on youtube
+!console:Searching Salsa music on YouTube - $!$
+{
+"url":"https://www.youtube.com/results?search_query=salsa+music",
+"path":"$"
+}
+eol
+# Ex: play salsa on youtube
+play salsa on youtube|play salsa music on youtube
+!example:play salsa on youtube
+!console:Searching Salsa music on YouTube - $!$
+{
+"url":"https://www.youtube.com/results?search_query=salsa+music",
+"path":"$"
+}
+eol
+# Ex: play salsa on youtube
+play salsa on youtube|play salsa music on youtube
+!example:play salsa on youtube
+!console:Searching Salsa music on YouTube - $!$
+{
+"url":"https://www.youtube.com/results?search_query=salsa+music",
+"path":"$"
+}
+eol


### PR DESCRIPTION
This PR fixes the "Play Salsa on YouTube" skill which was previously not behaving correctly.

Instead of returning a specific or broken YouTube video, the skill now redirects users to YouTube search results for Salsa music. This makes the response more reliable and user-friendly.

Changes made in:
models/general/Music and Audio/en/music.txt

## Summary by Sourcery

New Features:
- Change the Salsa playback intent to redirect users to YouTube search results for Salsa music rather than a single predetermined video.