### PR TITLE
Fix weather follow-up handling for time-based questions

### DIFF
--- a/models/general/Weather/en/Weather.txt
+++ b/models/general/Weather/en/Weather.txt
@@ -186,3 +186,14 @@ I would love to take something appropriate from me|I would like to have some cha
 what should I prefer when it's cold|what should I prefer when it is cold
 !example:what should I prefer when it's cold
 You should wear warm clothes and drink coffee.
+# Fix follow-up handling for weather questions (Issue #360)
+what was the weather *|how was the weather *
+!example:What was the weather like?
+!console:When exactly are you asking about?
+eol
+
+yesterday|today|tomorrow
+!example:yesterday
+!console:Fetching weather information for $1$ - $!$
+eol
+


### PR DESCRIPTION
This change fixes an issue where SUSI fails to correctly respond to weather
questions after asking a follow-up like "When was this exactly?".

The skill now properly handles responses such as "yesterday", "today",
and "tomorrow" instead of returning unrelated answers.

Fixes #360

## Summary by Sourcery

Bug Fixes:
- Ensure weather follow-up questions using relative times like "yesterday", "today", and "tomorrow" return appropriate weather responses instead of unrelated answers.