### PR TITLE
Add primary answer action to University skill (#253)

### DIFF
--- a/models/general/Knowledge/en/university.txt
+++ b/models/general/Knowledge/en/university.txt
@@ -7,15 +7,24 @@
 ::image images/university.png
 ::terms_of_use
 
-universities in *|tell me universities in * |do you know the universities in *|find universities in *| show universities in *| search for universities in *| name the universities in *| tell me about universities in *|give me list of universities in *| What all universities are in *|tell me names of universities in *|tell me the names of universities in *|can you tell me names of universities in *|can you tell me the names of universities in *|do you know the any universities in *|do you know the names of universities in *|which are universities in *|which universities are in *|Provide me list of universities in *|
-!example:universities in germany
-!console:Sure, here is a list of universities
+universities in *|tell me universities in *|do you know the universities in *|find universities in *|show universities in *|search for universities in *|name the universities in *|tell me about universities in *|give me list of universities in *|what all universities are in *|tell me names of universities in *|tell me the names of universities in *|can you tell me names of universities in *|can you tell me the names of universities in *|do you know any universities in *|do you know the names of universities in *|which are universities in *|which universities are in *|provide me list of universities in *
+!example: universities in Germany
+!expect: Sure, here is a list of universities in Germany.
+
+Sure, here is a list of universities in $1.
+
 {
-"url":"http://universities.hipolabs.com/search?country=$1$",
-"path":"$",
-"actions":[{
-"type":"table",
-"columns":{"name" : "Name", "country" : "Country", "web_pages" : "Website"}
-}]
+  "url": "http://universities.hipolabs.com/search?country=$1$",
+  "path": "$",
+  "actions": [
+    {
+      "type": "table",
+      "columns": {
+        "name": "Name",
+        "country": "Country",
+        "web_pages": "Website"
+      }
+    }
+  ]
 }
 eol


### PR DESCRIPTION
## Description

This PR adds a primary answer text to the University skill.

Previously, the skill only returned a table action.
For speech-to-text interfaces, a textual response is required.

Now, the skill first responds with:
"Sure, here is a list of universities in <country>."

The existing table action remains unchanged.

Fixes #253

## Summary by Sourcery

Enhancements:
- Introduce a leading natural-language response describing the university list for better support of speech-to-text and conversational interfaces.