### PR TITLE
feat: add Business and Entertainment News skills

### DIFF
--- a/models/general/News/business_news.txt
+++ b/models/general/News/business_news.txt
@@ -1,0 +1,26 @@
+::name Business News
+::author Your Name
+::author_url https://github.com/yourusername
+::description Get latest business news headlines.
+::dynamic_content Yes
+::developer_privacy_policy
+::image images/business_news.png
+::terms_of_use
+
+business news|latest business news|show me business news|tell me business news|business headlines
+!example:business news
+!console:Here are the latest business news headlines
+{
+  "url":"https://newsapi.org/v2/top-headlines?category=business&language=en&apiKey=YOUR_API_KEY",
+  "path":"$.articles[*]",
+  "actions":[
+    {
+      "type":"table",
+      "columns":{
+        "title":"Title",
+        "url":"Read More"
+      }
+    }
+  ]
+}
+eol

--- a/models/general/News/entertainment_news.txt
+++ b/models/general/News/entertainment_news.txt
@@ -1,0 +1,26 @@
+::name Entertainment News
+::author Your Name
+::author_url https://github.com/yourusername
+::description Get latest entertainment news headlines.
+::dynamic_content Yes
+::developer_privacy_policy
+::image images/entertainment_news.png
+::terms_of_use
+
+entertainment news|latest entertainment news|show me entertainment news|tell me entertainment news|entertainment headlines
+!example:entertainment news
+!console:Here are the latest entertainment news headlines
+{
+  "url":"https://newsapi.org/v2/top-headlines?category=entertainment&language=en&apiKey=YOUR_API_KEY",
+  "path":"$.articles[*]",
+  "actions":[
+    {
+      "type":"table",
+      "columns":{
+        "title":"Title",
+        "url":"Read More"
+      }
+    }
+  ]
+}
+eol


### PR DESCRIPTION
### Description
This PR adds two new news skills:
- Business News
- Entertainment News

These skills provide the latest headlines using News-API and are structured according to the SUSI skill format.

### Issue Reference
Closes #226

## Summary by Sourcery

Add new SUSI skills for fetching business and entertainment news headlines via News-API.

New Features:
- Introduce a Business News skill that returns the latest business headlines.
- Introduce an Entertainment News skill that returns the latest entertainment headlines.