### PR TITLE
Add SUSI skill to control Ardomower

### DIFF
--- a/models/general/Connected Car/en/ardomower/control.txt
+++ b/models/general/Connected Car/en/ardomower/control.txt
@@ -1,0 +1,19 @@
+::name Ardomower Control
+::author Pittu Sharma
+::description Control an Ardomower lawn mower using SUSI AI commands
+::dynamic_content No
+
+start mower
+Mower started.
+
+stop mower
+Mower stopped.
+
+move forward
+Moving forward.
+
+turn left
+Turning left.
+
+turn right
+Turning right.


### PR DESCRIPTION
### What does this PR do?

This PR adds a new SUSI skill that allows users to control an Ardomower (Arduino based lawn mower) using simple voice commands.

### Features

The skill supports commands such as:
- start mower
- stop mower
- move forward
- turn left
- turn right

### Why is this change needed?

This implements the idea discussed in issue #129 to demonstrate how SUSI skills can be used to control external hardware devices like an Arduino powered lawn mower.

### Notes

This change only adds a new skill file and does not modify any existing functionality.

## Summary by Sourcery

New Features:
- Introduce a SUSI skill for Ardomower to handle basic mower control commands like start, stop, and directional movement.