### PR TITLE
Add send message SUSI skill for Android and iOS clients

### DIFF
--- a/models/general/Communication/send_message/send_message.txt
+++ b/models/general/Communication/send_message/send_message.txt
@@ -1,0 +1,16 @@
+::name Send Message
+::author Pittu Sharma
+::description Send a message to a contact using SUSI AI
+::dynamic_content No
+
+send message *
+!console:Sending message to $1
+{
+"actions":[
+{
+"type":"sendmessage",
+"contact":"$1"
+}
+]
+}
+eol


### PR DESCRIPTION
This PR adds a new SUSI skill that allows users to ask SUSI to send a message to a contact.

Example query:
send message amit

This skill introduces a sendmessage action which can be handled by SUSI Android and iOS clients.

## Summary by Sourcery

New Features:
- Introduce a send_message SUSI skill that lets users request sending a message to a specified contact from supported clients.