### PR TITLE
Add set alarm SUSI skill for Android and iOS clients

### DIFF
--- a/models/general/Communication/en/set_alarm/set_alarm.txt
+++ b/models/general/Communication/en/set_alarm/set_alarm.txt
@@ -1,0 +1,16 @@
+::name Set Alarm
+::author Pittu Sharma
+::description Set an alarm using SUSI AI
+::dynamic_content No
+
+set alarm *
+!console:Setting alarm for $1
+{
+"actions":[
+{
+"type":"alarm",
+"time":"$1"
+}
+]
+}
+eol


### PR DESCRIPTION
### What does this PR do?

This PR adds a new SUSI skill that allows users to set an alarm using SUSI AI.

Example queries:
set alarm
set alarm for 8 am

### Purpose

This skill introduces an `alarm` action which can be used by Android and iOS clients to trigger alarm functionality.

### Notes

If the user specifies time, the alarm will be set for that time using the `alarm` action.

## Summary by Sourcery

New Features:
- Introduce a set-alarm SUSI skill that defines an alarm action for use by Android and iOS clients.