### PR TITLE
Add send mail SUSI skill for Android and iOS clients

### DIFF
--- a/models/general/Communication/en/send_mail/send_mail.txt
+++ b/models/general/Communication/en/send_mail/send_mail.txt
@@ -1,0 +1,16 @@
+::name Send Mail
+::author Pittu Sharma
+::description Send an email to a contact using SUSI AI
+::dynamic_content No
+
+send mail to *
+!console:Sending mail to $1
+{
+"actions":[
+{
+"type":"sendmail",
+"recipient":"$1"
+}
+]
+}
+eol


### PR DESCRIPTION
### What does this PR do?

This PR adds a new SUSI skill that allows users to ask SUSI to send an email to a contact.

Example query:
send mail to amit

### Purpose

This skill introduces a `sendmail` action which can be handled by SUSI Android and iOS clients to trigger email functionality.

### Notes

This change only adds a new skill file and does not modify any existing functionality.

## Summary by Sourcery

New Features:
- Introduce a send mail SUSI skill that lets users request sending an email to a named contact from Android and iOS clients.