### PR TITLE
Add SUSI skill to play YouTube videos

### DIFF
--- a/models/general/Music and Audio/en/youtube_video/youtube_video.txt
+++ b/models/general/Music and Audio/en/youtube_video/youtube_video.txt
@@ -1,0 +1,17 @@
+::name Play YouTube Video
+::author Pittu Sharma
+::description Play a YouTube video using SUSI AI
+::dynamic_content No
+
+play video
+!console:Playing video
+{
+"actions":[
+{
+"type":"playvideo",
+"identifier":"dQw4w9WgXcQ",
+"identifier_type":"youtube"
+}
+]
+}
+eol


### PR DESCRIPTION
### What does this PR do?

This PR adds a new SUSI skill that allows users to ask SUSI to play a YouTube video.

Example query:
play video

### Purpose

This skill introduces a `playvideo` action which can be used by SUSI clients to play YouTube videos.

### Notes

The skill demonstrates how SUSI can trigger video playback using YouTube identifiers.

## Summary by Sourcery

New Features:
- Introduce a YouTube video playback skill that enables SUSI to trigger video playback via a new action.